### PR TITLE
fixes an issue with InputStreams that contain trailer records

### DIFF
--- a/ffpojo/src/main/java/com/github/ffpojo/file/reader/InputStreamFlatFileReader.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/file/reader/InputStreamFlatFileReader.java
@@ -54,11 +54,12 @@ public class InputStreamFlatFileReader extends BaseFlatFileReader implements Fla
 			throw new NoSuchElementException("There are no more records to read");
 		}
 		try {
-            		String currLine = nextLine;
-        		nextLine = inputStreamReader.readLine();
-			Object record = parseRecordFromText(currLine);
-			this.recordText = nextLine;
-			recordIndex++;	
+            String currLine = nextLine;
+            nextLine = inputStreamReader.readLine();
+            Object record = parseRecordFromText(currLine);
+            this.recordText = nextLine;
+            recordIndex++;
+            return record;
 		} catch (IOException e) {
 			throw new RuntimeException("Error while decoding the line number " + (recordIndex + 1), e);
 		} catch (RecordParserException e) {

--- a/ffpojo/src/main/java/com/github/ffpojo/file/reader/InputStreamFlatFileReader.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/file/reader/InputStreamFlatFileReader.java
@@ -54,11 +54,11 @@ public class InputStreamFlatFileReader extends BaseFlatFileReader implements Fla
 			throw new NoSuchElementException("There are no more records to read");
 		}
 		try {
-			Object record = parseRecordFromText(nextLine);
+            		String currLine = nextLine;
+        		nextLine = inputStreamReader.readLine();
+			Object record = parseRecordFromText(currLine);
 			this.recordText = nextLine;
 			recordIndex++;	
-			nextLine = inputStreamReader.readLine();
-			return record;
 		} catch (IOException e) {
 			throw new RuntimeException("Error while decoding the line number " + (recordIndex + 1), e);
 		} catch (RecordParserException e) {


### PR DESCRIPTION
Trailer records were not handled correctly in input streams.  The body parser would be used on the trailer record because the nextLine member variable would be updated to null at the end of the file only after the trailer was processed.