### PR TITLE
Melhorias Solicitadas @gibaholms

### DIFF
--- a/ffpojo-samples/pom.xml
+++ b/ffpojo-samples/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.ffpojo</groupId>
 		<artifactId>ffpojo-parent</artifactId>
-		<version>1.1-SNAPSHOT</version>
+		<version>2.0.REPACKAGE</version>
 	</parent>
 	
 	<artifactId>ffpojo-samples</artifactId>

--- a/ffpojo-samples/src/main/java/com/github/ffpojo/samples/pojo/Customer.java
+++ b/ffpojo-samples/src/main/java/com/github/ffpojo/samples/pojo/Customer.java
@@ -7,7 +7,7 @@ import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
 import com.github.ffpojo.metadata.positional.annotation.extra.LongPositionalField;
 
-@PositionalRecord(ignorePositionNotFound=true)
+@PositionalRecord(ignoreMissingFieldsInTheEnd =true)
 public class Customer {
 
 	@LongPositionalField(initialPosition = 1, finalPosition = 5)

--- a/ffpojo/pom.xml
+++ b/ffpojo/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.github.ffpojo</groupId>
 		<artifactId>ffpojo-parent</artifactId>
-		<version>1.1-SNAPSHOT</version>
+		<version>2.0.REPACKAGE</version>
 	</parent>
 	
 	<artifactId>ffpojo</artifactId>
@@ -18,7 +18,7 @@
 		<dependency>
 		  <groupId>com.google.truth</groupId>
 		  <artifactId>truth</artifactId>
-		  <version>0.27</version>
+		  <version>0.31</version>
 		  <scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/ffpojo/src/main/java/com/github/ffpojo/FFPojoHelper.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/FFPojoHelper.java
@@ -1,8 +1,5 @@
 package com.github.ffpojo;
 
-import java.io.File;
-import java.util.List;
-
 import com.github.ffpojo.container.HybridMetadataContainer;
 import com.github.ffpojo.container.MetadataContainer;
 import com.github.ffpojo.exception.FFPojoException;
@@ -10,6 +7,9 @@ import com.github.ffpojo.exception.MetadataContainerException;
 import com.github.ffpojo.metadata.RecordDescriptor;
 import com.github.ffpojo.parser.RecordParser;
 import com.github.ffpojo.parser.RecordParserFactory;
+
+import java.io.File;
+import java.util.List;
 
 
 public class FFPojoHelper {

--- a/ffpojo/src/main/java/com/github/ffpojo/FFPojoHelper.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/FFPojoHelper.java
@@ -32,6 +32,10 @@ public class FFPojoHelper {
 		}
 		return singletonInstance;
 	}
+
+	public <T> List<T> getRecordsFromFile(String fileName, Class<T> recordClazz) throws FFPojoException {
+		return getRecordsFromFile(new File(fileName), recordClazz);
+	}
 	
 	@SuppressWarnings("unchecked")
 	public <T> List<T> getRecordsFromFile(File file, Class<T> recordClazz) throws FFPojoException {

--- a/ffpojo/src/main/java/com/github/ffpojo/decorator/InternalEnumDecorator.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/decorator/InternalEnumDecorator.java
@@ -29,7 +29,7 @@ public class InternalEnumDecorator extends ExtendedFieldDecorator<Enum<?>> {
     }
 
     public Enum fromString(String field) throws FieldDecoratorException {
-        if(field == null  ||  field.trim().isEmpty()){
+        if(field == null  ||  StringUtil.EMPTY.equalsIgnoreCase(field.trim())){
             return  null;
         }
         if (enumerationType.isString()){

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/FieldDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/FieldDescriptor.java
@@ -4,13 +4,16 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
 import com.github.ffpojo.metadata.positional.annotation.AccessorType;
+import com.github.ffpojo.util.ReflectUtil;
+import com.github.ffpojo.util.StringUtil;
 
 
 public abstract class FieldDescriptor {
 
 	private Method getter;
-	private Field field;
 	private AccessorType accessorType =  AccessorType.PROPERTY;
+	private boolean isFullLineField;
+	private Field field;
 		
 	// GETTERS AND SETTERS
 	
@@ -20,24 +23,37 @@ public abstract class FieldDescriptor {
 	public void setGetter(Method getter) {
 		this.getter = getter;
 	}
-	public Field getField() {
-		return field;
-	}
-	public void setField(Field field) {
-		this.field = field;
-	}
 	public AccessorType getAccessorType() {
 		return accessorType;
 	}
 	public void setAccessorType(AccessorType accessorType) {
 		this.accessorType = accessorType;
 	}
-
-	public boolean isByField(){
-		return this.accessorType.isByField();
+	public boolean isFullLineField() {
+		return isFullLineField;
+	}
+	public void setIsFullLineField(boolean isFullLineField) {
+		this.isFullLineField = isFullLineField;
 	}
 
-	public boolean isByProperty(){
-		return this.accessorType.isByProperty();
+	public String getFieldDescriptorName(){
+		String fieldName = "";
+		if (getter!= null){
+			fieldName =  getter.getName();
+		}else if (field != null){
+			fieldName =  field.getName();
+		}
+		return StringUtil.pastelCaseToCamelCase(fieldName);
 	}
+
+	private String getterToFieldName(Method getter){
+		if (getter == null) return null;
+		String getName=  getter.getName();
+		if (getName.startsWith("get")){
+			return getName.substring(3);
+		}
+		return getName.substring(2);
+
+	}
+
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/FieldDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/FieldDescriptor.java
@@ -3,6 +3,7 @@ package com.github.ffpojo.metadata;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 
+import com.github.ffpojo.metadata.positional.PositionalFieldDescriptor;
 import com.github.ffpojo.metadata.positional.annotation.AccessorType;
 import com.github.ffpojo.util.ReflectUtil;
 import com.github.ffpojo.util.StringUtil;
@@ -11,10 +12,9 @@ import com.github.ffpojo.util.StringUtil;
 public abstract class FieldDescriptor {
 
 	private Method getter;
-	private AccessorType accessorType =  AccessorType.PROPERTY;
 	private boolean isFullLineField;
-	private Field field;
-		
+	private FieldDecorator<?> decorator;
+
 	// GETTERS AND SETTERS
 	
 	public Method getGetter() {
@@ -23,12 +23,6 @@ public abstract class FieldDescriptor {
 	public void setGetter(Method getter) {
 		this.getter = getter;
 	}
-	public AccessorType getAccessorType() {
-		return accessorType;
-	}
-	public void setAccessorType(AccessorType accessorType) {
-		this.accessorType = accessorType;
-	}
 	public boolean isFullLineField() {
 		return isFullLineField;
 	}
@@ -36,24 +30,30 @@ public abstract class FieldDescriptor {
 		this.isFullLineField = isFullLineField;
 	}
 
-	public String getFieldDescriptorName(){
-		String fieldName = "";
-		if (getter!= null){
-			fieldName =  getter.getName();
-		}else if (field != null){
-			fieldName =  field.getName();
-		}
+	protected String getFieldDescriptorName(){
+		final String fieldName = ReflectUtil.getFieldNameFromGetterOrSetter(getter);
 		return StringUtil.pastelCaseToCamelCase(fieldName);
 	}
 
-	private String getterToFieldName(Method getter){
-		if (getter == null) return null;
-		String getName=  getter.getName();
-		if (getName.startsWith("get")){
-			return getName.substring(3);
+	protected int compareFieldDescriptorFullLine(FieldDescriptor other){
+		if (this.isFullLineField()){
+			return 1;
 		}
-		return getName.substring(2);
+		if(other.isFullLineField()){
+			return -1;
+		}
+		return 0;
+	}
 
+	protected int compareGetterName(PositionalFieldDescriptor other){
+		return  this.getFieldDescriptorName().compareTo(other.getFieldDescriptorName());
+	}
+
+	public FieldDecorator<?> getDecorator() {
+		return decorator;
+	}
+	public void setDecorator(FieldDecorator<?> decorator) {
+		this.decorator = decorator;
 	}
 
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/FullLineField.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/FullLineField.java
@@ -1,0 +1,15 @@
+package com.github.ffpojo.metadata;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by William on 16/11/15.
+ * @author William Mirnda de Jesus - blackstile@hotmail.com
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD})
+public @interface FullLineField {
+}

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/delimited/DelimitedFieldDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/delimited/DelimitedFieldDescriptor.java
@@ -7,9 +7,13 @@ import com.github.ffpojo.metadata.FieldDescriptor;
 public class DelimitedFieldDescriptor extends FieldDescriptor implements Comparable<DelimitedFieldDescriptor> {
 
 	private int positionIndex;
-	private FieldDecorator<?> decorator;
-	
+
 	public int compareTo(DelimitedFieldDescriptor other) {
+		int resultCompareFullLine = compareFieldDescriptorFullLine(other);
+		if(resultCompareFullLine != 0){
+			return resultCompareFullLine;
+		}
+
 		if (this.positionIndex - other.positionIndex == 0) {
 			return this.getGetter().getName().compareTo(other.getGetter().getName());
 		} else {
@@ -25,10 +29,5 @@ public class DelimitedFieldDescriptor extends FieldDescriptor implements Compara
 	public void setPositionIndex(int positionIndex) {
 		this.positionIndex = positionIndex;
 	}
-	public FieldDecorator<?> getDecorator() {
-		return decorator;
-	}
-	public void setDecorator(FieldDecorator<?> decorator) {
-		this.decorator = decorator;
-	}
+
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
@@ -5,7 +5,7 @@ import com.github.ffpojo.decorator.*;
 import com.github.ffpojo.exception.FFPojoException;
 import com.github.ffpojo.exception.MetadataReaderException;
 import com.github.ffpojo.metadata.FieldDecorator;
-import com.github.ffpojo.metadata.positional.annotation.extra.RemainPositionalField;
+import com.github.ffpojo.metadata.positional.annotation.extra.PositionalFieldRemainder;
 import com.github.ffpojo.util.ReflectUtil;
 
 import java.lang.annotation.Annotation;
@@ -14,7 +14,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-public class FFPojoAnnotationFieldManager {
+    public class FFPojoAnnotationFieldManager {
 
     final private static Map<String, Class<? extends FieldDecorator<?>>> mapAnnotationDecoratorClass = new HashMap<String,  Class<? extends FieldDecorator<?>>>();
 
@@ -48,7 +48,7 @@ public class FFPojoAnnotationFieldManager {
     }
 
     public boolean isRemainPositionalField(Class<? extends Annotation> annotation){
-        return annotation.isAssignableFrom(RemainPositionalField.class);
+        return annotation.isAssignableFrom(PositionalFieldRemainder.class);
     }
 
     public boolean isPositionalField(Class<? extends Annotation> annotation){

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
@@ -76,8 +76,12 @@ public class FFPojoAnnotationFieldManager {
         return true;
     }
 
-
-    public boolean isFieldAlreadyFFPojoAnnotation( Field field) {
+    /**
+     * Verify if exist a FFPOjo Annotation (@PositionalField, @DelimitedField, @FullLineField, @PositionalFieldRemainder) on field
+     * @param field
+     * @return
+     */
+    public boolean isFieldAnnotedWithFFPojoAnnotation(Field field) {
         Annotation[] annotationsField =  field.getAnnotations();
         boolean hasFieldAnnotaded =  false;
         for (int i = 0; i < annotationsField.length; i++) {

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
@@ -49,14 +49,6 @@ public class FFPojoAnnotationFieldManager {
         return isDelimitedField(annotation) || isPositionalField(annotation) || isFullLineField(annotation);
     }
 
-    public boolean isFullLineField(Class<? extends Annotation> annotation){
-        return annotation!=null && annotation.isAssignableFrom(FullLineField.class);
-    }
-
-    public boolean isPositionalFieldRemainder(Class<? extends Annotation> annotation){
-        return annotation!=null && annotation.isAssignableFrom(PositionalFieldRemainder.class);
-    }
-
     public boolean isPositionalField(Class<? extends Annotation> annotation){
         try{
             annotation.getMethod("initialPosition");
@@ -65,6 +57,14 @@ public class FFPojoAnnotationFieldManager {
             return isPositionalFieldRemainder(annotation) || isFullLineField(annotation);
         }
         return true;
+    }
+
+    public boolean isFullLineField(Class<? extends Annotation> annotation){
+        return annotation!=null && annotation.isAssignableFrom(FullLineField.class);
+    }
+
+    public boolean isPositionalFieldRemainder(Class<? extends Annotation> annotation){
+        return annotation!=null && annotation.isAssignableFrom(PositionalFieldRemainder.class);
     }
 
     public boolean isDelimitedField(Class<? extends Annotation> annotation){

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
@@ -5,6 +5,7 @@ import com.github.ffpojo.decorator.*;
 import com.github.ffpojo.exception.FFPojoException;
 import com.github.ffpojo.exception.MetadataReaderException;
 import com.github.ffpojo.metadata.FieldDecorator;
+import com.github.ffpojo.metadata.FullLineField;
 import com.github.ffpojo.metadata.positional.annotation.extra.PositionalFieldRemainder;
 import com.github.ffpojo.util.ReflectUtil;
 
@@ -14,7 +15,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-    public class FFPojoAnnotationFieldManager {
+public class FFPojoAnnotationFieldManager {
 
     final private static Map<String, Class<? extends FieldDecorator<?>>> mapAnnotationDecoratorClass = new HashMap<String,  Class<? extends FieldDecorator<?>>>();
 
@@ -30,6 +31,7 @@ import java.util.Map;
         mapAnnotationDecoratorClass.put("bigdecimal", InternalBigDecimalDecorator.class);
         mapAnnotationDecoratorClass.put("biginteger", InternalBigIntegerDecorator.class);
         mapAnnotationDecoratorClass.put("enum", InternalEnumDecorator.class);
+
     }
 
     public Class<?> getClassDecorator(Class<? extends Annotation> clazzPositionalFieldAnnotation){
@@ -44,11 +46,15 @@ import java.util.Map;
     }
 
     public boolean isFFPojoAnnotationField(Class<? extends Annotation> annotation){
-        return isDelimitedField(annotation) || isPositionalField(annotation);
+        return isDelimitedField(annotation) || isPositionalField(annotation) || isFullLineField(annotation);
     }
 
-    public boolean isRemainPositionalField(Class<? extends Annotation> annotation){
-        return annotation.isAssignableFrom(PositionalFieldRemainder.class);
+    public boolean isFullLineField(Class<? extends Annotation> annotation){
+        return annotation!=null && annotation.isAssignableFrom(FullLineField.class);
+    }
+
+    public boolean isPositionalFieldRemainder(Class<? extends Annotation> annotation){
+        return annotation!=null && annotation.isAssignableFrom(PositionalFieldRemainder.class);
     }
 
     public boolean isPositionalField(Class<? extends Annotation> annotation){
@@ -56,7 +62,7 @@ import java.util.Map;
             annotation.getMethod("initialPosition");
             annotation.getMethod("finalPosition");
         }catch (Exception e){
-            return isRemainPositionalField(annotation);
+            return isPositionalFieldRemainder(annotation);
         }
         return true;
     }
@@ -111,7 +117,7 @@ import java.util.Map;
 
     @SuppressWarnings("all")
     private FieldDecorator<?> getDecoratorInstance(Annotation annotation){
-		Class<? extends FieldDecorator> decorator = null;
+        Class<? extends FieldDecorator> decorator = null;
         try {
             decorator = (Class<? extends FieldDecorator>) annotation.getClass().getMethod("decorator").invoke(annotation);
             return decorator.newInstance();

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManager.java
@@ -62,7 +62,7 @@ public class FFPojoAnnotationFieldManager {
             annotation.getMethod("initialPosition");
             annotation.getMethod("finalPosition");
         }catch (Exception e){
-            return isPositionalFieldRemainder(annotation);
+            return isPositionalFieldRemainder(annotation) || isFullLineField(annotation);
         }
         return true;
     }
@@ -71,7 +71,7 @@ public class FFPojoAnnotationFieldManager {
         try{
             annotation.getMethod("positionIndex");
         }catch (Exception e){
-            return false;
+            return isFullLineField(annotation);
         }
         return true;
     }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptor.java
@@ -16,7 +16,6 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 	private boolean trimOnRead;
 	private FieldDecorator<?> decorator;
 	private boolean ignoreMissingFieldsInTheEnd;
-	private boolean remainPosition;
 
 	public int compareTo(PositionalFieldDescriptor other) {
 		int resultCompareFullLine = comparePositionalFullLine(other);
@@ -52,10 +51,10 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 	}
 
 	private int comparePositionalFieldRemainder(PositionalFieldDescriptor other){
-		if (this.isPositionalFieldRemainder()){
+		if (this.isIgnoreMissingFieldsInTheEnd() && !other.isFullLineField()){
 			return 1;
 		}
-		if(other.isPositionalFieldRemainder()){
+		if(other.isIgnoreMissingFieldsInTheEnd() || other.isFullLineField()){
 			return -1;
 		}
 		return 0;
@@ -107,14 +106,5 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 	public void setIgnoreMissingFieldsInTheEnd(boolean ignoreMissingFieldsInTheEnd) {
 		this.ignoreMissingFieldsInTheEnd = ignoreMissingFieldsInTheEnd;
 	}
-
-	public boolean isPositionalFieldRemainder() {
-		return remainPosition;
-	}
-
-	public void setRemainPosition(boolean remainPosition) {
-		this.remainPosition = remainPosition;
-	}
-
 
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptor.java
@@ -15,7 +15,7 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 	private char paddingCharacter;
 	private boolean trimOnRead;
 	private FieldDecorator<?> decorator;
-	private boolean ignoreMissingFieldsInTheEnd;
+	private boolean isPositionalFieldRemainder;
 
 	public int compareTo(PositionalFieldDescriptor other) {
 		int resultCompareFullLine = comparePositionalFullLine(other);
@@ -51,10 +51,10 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 	}
 
 	private int comparePositionalFieldRemainder(PositionalFieldDescriptor other){
-		if (this.isIgnoreMissingFieldsInTheEnd() && !other.isFullLineField()){
+		if (this.isPositionalFieldRemainder() && !other.isFullLineField()){
 			return 1;
 		}
-		if(other.isIgnoreMissingFieldsInTheEnd() || other.isFullLineField()){
+		if(other.isPositionalFieldRemainder() || other.isFullLineField()){
 			return -1;
 		}
 		return 0;
@@ -99,12 +99,11 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 		this.trimOnRead = trimOnRead;
 	}
 
-	public boolean isIgnoreMissingFieldsInTheEnd() {
-		return ignoreMissingFieldsInTheEnd;
+	public boolean isPositionalFieldRemainder() {
+		return isPositionalFieldRemainder;
 	}
 
-	public void setIgnoreMissingFieldsInTheEnd(boolean ignoreMissingFieldsInTheEnd) {
-		this.ignoreMissingFieldsInTheEnd = ignoreMissingFieldsInTheEnd;
+	public void setIsPositionalFieldRemainder(boolean isPositionalFieldRemainder) {
+		this.isPositionalFieldRemainder = isPositionalFieldRemainder;
 	}
-
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptor.java
@@ -15,25 +15,24 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 	private char paddingCharacter;
 	private boolean trimOnRead;
 	private FieldDecorator<?> decorator;
-	private boolean ignorePositionNotFound;
+	private boolean ignoreMissingFieldsInTheEnd;
 	private boolean remainPosition;
 
 	public int compareTo(PositionalFieldDescriptor other) {
-		if (this.isRemainPosition()){
-			return 1;
+		int resultCompareFullLine = comparePositionalFullLine(other);
+		if(resultCompareFullLine != 0){
+			return resultCompareFullLine;
 		}
-		if(other.isRemainPosition()){
-			return -1;
+
+		int resultCompareFieldRemainder =  comparePositionalFieldRemainder(other);
+		if(resultCompareFieldRemainder != 0){
+			return resultCompareFieldRemainder;
 		}
+
 		if (this.initialPosition - other.initialPosition == 0) {
 
 			if (this.finalPosition - other.finalPosition == 0) {
-				if (this.isByProperty()){
-					return this.getGetter().getName().compareTo(other.getGetter().getName());
-				}else{
-					return this.getField() == null ? -1 : other.getField() == null ?  1 :
-							this.getField().getName().compareTo(other.getField().getName());
-				}
+				return this.getGetter().getName().compareTo(other.getGetter().getName());
 			} else {
 				return this.finalPosition - other.finalPosition;
 			}
@@ -41,7 +40,27 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 			return this.initialPosition - other.initialPosition;
 		}
 	}
-	
+
+	private int comparePositionalFullLine(PositionalFieldDescriptor other){
+		if (this.isFullLineField()){
+			return 1;
+		}
+		if(other.isFullLineField()){
+			return -1;
+		}
+		return 0;
+	}
+
+	private int comparePositionalFieldRemainder(PositionalFieldDescriptor other){
+		if (this.isPositionalFieldRemainder()){
+			return 1;
+		}
+		if(other.isPositionalFieldRemainder()){
+			return -1;
+		}
+		return 0;
+	}
+
 	// GETTERS AND SETTERS
 	
 	public int getInitialPosition() {
@@ -81,15 +100,15 @@ public class PositionalFieldDescriptor extends FieldDescriptor implements Compar
 		this.trimOnRead = trimOnRead;
 	}
 
-	public boolean isIgnorePositionNotFound() {
-		return ignorePositionNotFound;
+	public boolean isIgnoreMissingFieldsInTheEnd() {
+		return ignoreMissingFieldsInTheEnd;
 	}
 
-	public void setIgnorePositionNotFound(boolean ignorePositionNotFound) {
-		this.ignorePositionNotFound = ignorePositionNotFound;
+	public void setIgnoreMissingFieldsInTheEnd(boolean ignoreMissingFieldsInTheEnd) {
+		this.ignoreMissingFieldsInTheEnd = ignoreMissingFieldsInTheEnd;
 	}
 
-	public boolean isRemainPosition() {
+	public boolean isPositionalFieldRemainder() {
 		return remainPosition;
 	}
 

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalRecordDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalRecordDescriptor.java
@@ -70,7 +70,7 @@ public class PositionalRecordDescriptor extends RecordDescriptor {
 	}
 
     private boolean canSkipValidation(PositionalFieldDescriptor actualFieldDescriptor) {
-        return actualFieldDescriptor.isIgnoreMissingFieldsInTheEnd() || actualFieldDescriptor.isFullLineField();
+        return actualFieldDescriptor.isPositionalFieldRemainder() || actualFieldDescriptor.isFullLineField();
     }
 
 

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalRecordDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalRecordDescriptor.java
@@ -70,7 +70,7 @@ public class PositionalRecordDescriptor extends RecordDescriptor {
 	}
 
     private boolean canSkipValidation(PositionalFieldDescriptor actualFieldDescriptor) {
-        return actualFieldDescriptor.isPositionalFieldRemainder() || actualFieldDescriptor.isFullLineField();
+        return actualFieldDescriptor.isIgnoreMissingFieldsInTheEnd() || actualFieldDescriptor.isFullLineField();
     }
 
 

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalRecordDescriptor.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/PositionalRecordDescriptor.java
@@ -13,7 +13,7 @@ import com.github.ffpojo.metadata.RecordDescriptor;
  */
 public class PositionalRecordDescriptor extends RecordDescriptor {
 
-	private boolean ignorePositionNotFound = false;
+	private boolean ignoreMissingFieldsInTheEnd = false;
 	
 	public PositionalRecordDescriptor() {
 		super();
@@ -33,7 +33,7 @@ public class PositionalRecordDescriptor extends RecordDescriptor {
 		if (positionalFieldDescriptors != null && !positionalFieldDescriptors.isEmpty()) {
 			for (int i = 0; i < positionalFieldDescriptors.size(); i++) {
 				PositionalFieldDescriptor actualFieldDescriptor = positionalFieldDescriptors.get(i);
-				if (actualFieldDescriptor.isRemainPosition()){
+				if (canSkipValidation(actualFieldDescriptor)){
 					continue;
 				}
 				boolean isFirstFieldDescriptor = i==0;
@@ -69,14 +69,13 @@ public class PositionalRecordDescriptor extends RecordDescriptor {
 		}
 	}
 
-	private String getFieldName(PositionalFieldDescriptor fieldDescriptor) {
-		String previousName = "";
-		if (fieldDescriptor.isByProperty()){
-            previousName =  fieldDescriptor.getGetter().getName();
-        }else {
-            previousName =  fieldDescriptor.getField().getName();
-        }
-		return previousName;
+    private boolean canSkipValidation(PositionalFieldDescriptor actualFieldDescriptor) {
+        return actualFieldDescriptor.isPositionalFieldRemainder() || actualFieldDescriptor.isFullLineField();
+    }
+
+
+    private String getFieldName(PositionalFieldDescriptor fieldDescriptor) {
+		return fieldDescriptor.getGetter().getName();
 	}
 
 	private void sortAndRemoveRepeated(List<PositionalFieldDescriptor> positionalFieldDescriptors) {
@@ -99,12 +98,12 @@ public class PositionalRecordDescriptor extends RecordDescriptor {
 		}
 	}
 
-	public boolean isIgnorePositionNotFound() {
-		return ignorePositionNotFound;
+	public boolean isIgnoreMissingFieldsInTheEnd() {
+		return ignoreMissingFieldsInTheEnd;
 	}
 
-	public void setIgnorePositionNotFound(boolean ignorePositionNotFound) {
-		this.ignorePositionNotFound = ignorePositionNotFound;
+	public void setIgnoreMissingFieldsInTheEnd(boolean ignoreMissingFieldsInTheEnd) {
+		this.ignoreMissingFieldsInTheEnd = ignoreMissingFieldsInTheEnd;
 	}
 	
 	

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/PositionalRecord.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/PositionalRecord.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE})
 public @interface PositionalRecord {
-	boolean ignorePositionNotFound() default false;
+	boolean ignoreMissingFieldsInTheEnd() default false;
+	boolean isGetterAndSetterMethodOptional() default true;
 	PositionalRecordLineIdentifier[] lineIdentifiers() default {};
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/PositionalRecord.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/PositionalRecord.java
@@ -9,6 +9,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE})
 public @interface PositionalRecord {
 	boolean ignorePositionNotFound() default false;
-	boolean autoFillRemainPosition() default false;
 	PositionalRecordLineIdentifier[] lineIdentifiers() default {};
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/PositionalRecord.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/PositionalRecord.java
@@ -9,6 +9,5 @@ import java.lang.annotation.Target;
 @Target({ElementType.TYPE})
 public @interface PositionalRecord {
 	boolean ignoreMissingFieldsInTheEnd() default false;
-	boolean isGetterAndSetterMethodOptional() default true;
 	PositionalRecordLineIdentifier[] lineIdentifiers() default {};
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/extra/DatePositionalField.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/extra/DatePositionalField.java
@@ -10,7 +10,7 @@ import com.github.ffpojo.metadata.positional.PaddingAlign;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
 public @interface DatePositionalField {
-	String dateFormat();
+	String dateFormat() default "DDMMYYYY";
 	int initialPosition();
 	int finalPosition();
 	PaddingAlign paddingAlign() default PaddingAlign.RIGHT;

--- a/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/extra/PositionalFieldRemainder.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/metadata/positional/annotation/extra/PositionalFieldRemainder.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
-public @interface RemainPositionalField {
+public @interface PositionalFieldRemainder {
 	PaddingAlign paddingAlign() default PaddingAlign.RIGHT;
 	char paddingCharacter() default ' ';
 	boolean trimOnRead() default true;

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/BaseRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/BaseRecordParser.java
@@ -7,12 +7,16 @@ import com.github.ffpojo.metadata.FieldDecorator;
 import com.github.ffpojo.metadata.FieldDescriptor;
 import com.github.ffpojo.metadata.RecordDescriptor;
 import com.github.ffpojo.metadata.delimited.DelimitedFieldDescriptor;
+import com.github.ffpojo.metadata.positional.PositionalFieldDescriptor;
 import com.github.ffpojo.util.ReflectUtil;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.logging.Logger;
 
 abstract class BaseRecordParser implements RecordParser {
+
+	protected static final Logger logger =  Logger.getLogger("global");
 
 	protected RecordDescriptor recordDescriptor;
 	
@@ -22,6 +26,14 @@ abstract class BaseRecordParser implements RecordParser {
 
 	protected RecordDescriptor getRecordDescriptor() {
 		return recordDescriptor;
+	}
+
+	protected  <T> void setValue(T record, FieldDescriptor actualFieldDescriptor, String fieldValue, Method setter) {
+		if (setter != null){
+			setValueBySetterMethod(record, actualFieldDescriptor, fieldValue, setter);
+		}else{
+			setValueByField(record, actualFieldDescriptor, fieldValue);
+		}
 	}
 
 	protected  <T> void setValueByField(T record, FieldDescriptor actualFieldDescriptor, String fieldValue){

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/BaseRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/BaseRecordParser.java
@@ -1,6 +1,16 @@
 package com.github.ffpojo.parser;
 
+import com.github.ffpojo.exception.FFPojoException;
+import com.github.ffpojo.exception.FieldDecoratorException;
+import com.github.ffpojo.exception.RecordParserException;
+import com.github.ffpojo.metadata.FieldDecorator;
+import com.github.ffpojo.metadata.FieldDescriptor;
 import com.github.ffpojo.metadata.RecordDescriptor;
+import com.github.ffpojo.metadata.delimited.DelimitedFieldDescriptor;
+import com.github.ffpojo.util.ReflectUtil;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 
 abstract class BaseRecordParser implements RecordParser {
 
@@ -13,5 +23,33 @@ abstract class BaseRecordParser implements RecordParser {
 	protected RecordDescriptor getRecordDescriptor() {
 		return recordDescriptor;
 	}
-	
+
+	protected  <T> void setValueByField(T record, FieldDescriptor actualFieldDescriptor, String fieldValue){
+		FieldDecorator<?> decorator = actualFieldDescriptor.getDecorator();
+		Object parameter = decorator.fromString(fieldValue);
+		final Method getter = actualFieldDescriptor.getGetter();
+		final String fieldName =  ReflectUtil.getFieldNameFromGetterOrSetter(getter);
+		try{
+			final Field field = ReflectUtil.getField(record.getClass(), fieldName);
+			field.setAccessible(true);
+			field.set(record, parameter);
+		}catch (Exception e){
+			throw new FFPojoException(e);
+		}
+	}
+
+
+	protected  <T> void setValueBySetterMethod(T record, FieldDescriptor actualFieldDescriptor, String fieldValue, Method setter) {
+		Object parameter;
+		try {
+			FieldDecorator<?> decorator = actualFieldDescriptor.getDecorator();
+			parameter = decorator.fromString(fieldValue);
+			if (setter != null)
+				setter.invoke(record, parameter);
+		} catch (FieldDecoratorException e) {
+			throw new RecordParserException(e);
+		} catch (Exception e) {
+			throw new RecordParserException("Error while invoking setter method, make sure that is provided a compatible fromString decorator method: " + setter, e);
+		}
+	}
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/DelimitedRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/DelimitedRecordParser.java
@@ -1,20 +1,17 @@
 package com.github.ffpojo.parser;
 
-import com.github.ffpojo.exception.FFPojoException;
 import com.github.ffpojo.exception.FieldDecoratorException;
 import com.github.ffpojo.exception.RecordParserException;
 import com.github.ffpojo.metadata.FieldDecorator;
 import com.github.ffpojo.metadata.delimited.DelimitedFieldDescriptor;
 import com.github.ffpojo.metadata.delimited.DelimitedRecordDescriptor;
-import com.github.ffpojo.metadata.positional.PositionalFieldDescriptor;
 import com.github.ffpojo.util.ReflectUtil;
 import com.github.ffpojo.util.RegexUtil;
 import com.github.ffpojo.util.StringUtil;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.List;
-
+import java.util.logging.Logger;
 
 
 class DelimitedRecordParser extends BaseRecordParser implements RecordParser {
@@ -50,18 +47,10 @@ class DelimitedRecordParser extends BaseRecordParser implements RecordParser {
 				try {
 					setter = ReflectUtil.getSetterFromGetter(actualFieldDescriptor.getGetter(), new Class<?>[]{getterReturnType}, recordClazz);
 				} catch (NoSuchMethodException e2) {
-					e2.printStackTrace();
-//					throw new RecordParserException("Compatible setter not found for getter " + actualFieldDescriptor.getGetter(), e2);
+					logger.warning("Compatible setter not found for getter " + actualFieldDescriptor.getGetter());
 				}
 			}
-
-			if (setter != null){
-				setValueBySetterMethod(record, actualFieldDescriptor, fieldValue, setter);
-
-			}else{
-				setValueByField(record, actualFieldDescriptor, fieldValue);
-			}
-
+			setValue(record, actualFieldDescriptor, fieldValue, setter);
 
 		}
 		

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/DelimitedRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/DelimitedRecordParser.java
@@ -32,11 +32,13 @@ class DelimitedRecordParser extends BaseRecordParser implements RecordParser {
 		String[] textTokens = text.split(RegexUtil.escapeRegexMetacharacters(getRecordDescriptor().getDelimiter()), -1);
 		int tokensQtt = textTokens.length;
 		for (DelimitedFieldDescriptor actualFieldDescriptor : delimitedFieldDescriptors) {
-			String fieldValue;
-			if (actualFieldDescriptor.getPositionIndex() <= tokensQtt) {
-				fieldValue = textTokens[actualFieldDescriptor.getPositionIndex() - 1];
-			} else {
-				throw new RecordParserException("The position declared in field-mapping is greater than the text tokens amount: " + actualFieldDescriptor.getGetter());
+			String fieldValue = text;
+			if (!actualFieldDescriptor.isFullLineField()){
+				if (actualFieldDescriptor.getPositionIndex() <= tokensQtt) {
+					fieldValue = textTokens[actualFieldDescriptor.getPositionIndex() - 1];
+				} else {
+					throw new RecordParserException("The position declared in field-mapping is greater than the text tokens amount: " + actualFieldDescriptor.getGetter());
+				}
 			}
 
 			Method setter =null;

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/DelimitedRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/DelimitedRecordParser.java
@@ -1,19 +1,16 @@
 package com.github.ffpojo.parser;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.List;
-
-import com.github.ffpojo.exception.FFPojoException;
 import com.github.ffpojo.exception.FieldDecoratorException;
 import com.github.ffpojo.exception.RecordParserException;
 import com.github.ffpojo.metadata.FieldDecorator;
 import com.github.ffpojo.metadata.delimited.DelimitedFieldDescriptor;
 import com.github.ffpojo.metadata.delimited.DelimitedRecordDescriptor;
-import com.github.ffpojo.metadata.positional.annotation.AccessorType;
 import com.github.ffpojo.util.ReflectUtil;
 import com.github.ffpojo.util.RegexUtil;
 import com.github.ffpojo.util.StringUtil;
+
+import java.lang.reflect.Method;
+import java.util.List;
 
 
 
@@ -34,9 +31,7 @@ class DelimitedRecordParser extends BaseRecordParser implements RecordParser {
 		List<DelimitedFieldDescriptor> delimitedFieldDescriptors = getRecordDescriptor().getFieldDescriptors();
 		String[] textTokens = text.split(RegexUtil.escapeRegexMetacharacters(getRecordDescriptor().getDelimiter()), -1);
 		int tokensQtt = textTokens.length;
-		for(int i = 0; i < delimitedFieldDescriptors.size(); i++) {
-			DelimitedFieldDescriptor actualFieldDescriptor = delimitedFieldDescriptors.get(i);
-			
+		for (DelimitedFieldDescriptor actualFieldDescriptor : delimitedFieldDescriptors) {
 			String fieldValue;
 			if (actualFieldDescriptor.getPositionIndex() <= tokensQtt) {
 				fieldValue = textTokens[actualFieldDescriptor.getPositionIndex() - 1];
@@ -44,42 +39,29 @@ class DelimitedRecordParser extends BaseRecordParser implements RecordParser {
 				throw new RecordParserException("The position declared in field-mapping is greater than the text tokens amount: " + actualFieldDescriptor.getGetter());
 			}
 
-			if(actualFieldDescriptor.getAccessorType().equals(AccessorType.FIELD)){
-				Field field = actualFieldDescriptor.getField();
-				field.setAccessible(true);
+			Method setter;
+			Class<?> getterReturnType = actualFieldDescriptor.getGetter().getReturnType();
+			try {
+				setter = ReflectUtil.getSetterFromGetter(actualFieldDescriptor.getGetter(), new Class<?>[]{String.class}, recordClazz);
+			} catch (NoSuchMethodException e1) {
 				try {
-					Object value =  actualFieldDescriptor.getDecorator().fromString(fieldValue);
-					field.set(record, value);
-				} catch (Exception e) {
-					throw new FFPojoException(e);
-				}
-			}else{
-				Method setter;
-				Class<?> getterReturnType = actualFieldDescriptor.getGetter().getReturnType();
-				try {
-					setter = ReflectUtil.getSetterFromGetter(actualFieldDescriptor.getGetter(), new Class<?>[] {String.class}, recordClazz);
-				} catch (NoSuchMethodException e1) {
-					try {
-						setter = ReflectUtil.getSetterFromGetter(actualFieldDescriptor.getGetter(), new Class<?>[] {getterReturnType}, recordClazz);
-					} catch (NoSuchMethodException e2) {
-						throw new RecordParserException("Compatible setter not found for getter " + actualFieldDescriptor.getGetter(), e2);
-					}
-				}
-
-				Object parameter;
-				try {
-					FieldDecorator<?> decorator = actualFieldDescriptor.getDecorator();
-					parameter = decorator.fromString(fieldValue);
-					if (setter != null)
-						setter.invoke(record, parameter);
-				} catch (FieldDecoratorException e) {
-					throw new RecordParserException(e);
-				} catch (Exception e) {
-					throw new RecordParserException("Error while invoking setter method, make sure that is provided a compatible fromString decorator method: " + setter, e);
+					setter = ReflectUtil.getSetterFromGetter(actualFieldDescriptor.getGetter(), new Class<?>[]{getterReturnType}, recordClazz);
+				} catch (NoSuchMethodException e2) {
+					throw new RecordParserException("Compatible setter not found for getter " + actualFieldDescriptor.getGetter(), e2);
 				}
 			}
 
-
+			Object parameter;
+			try {
+				FieldDecorator<?> decorator = actualFieldDescriptor.getDecorator();
+				parameter = decorator.fromString(fieldValue);
+				if (setter != null)
+					setter.invoke(record, parameter);
+			} catch (FieldDecoratorException e) {
+				throw new RecordParserException(e);
+			} catch (Exception e) {
+				throw new RecordParserException("Error while invoking setter method, make sure that is provided a compatible fromString decorator method: " + setter, e);
+			}
 
 		}
 		
@@ -103,7 +85,7 @@ class DelimitedRecordParser extends BaseRecordParser implements RecordParser {
 			Method getter = actualFieldDescriptor.getGetter();
 			Object fieldValueObj;
 			try {
-				fieldValueObj = getter.invoke(record, new Object[]{});
+				fieldValueObj = getter.invoke(record);
 			} catch (Exception e) {
 				throw new RecordParserException("Error while invoking getter method: " + getter, e);
 			} 

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/DelimitedRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/DelimitedRecordParser.java
@@ -32,7 +32,7 @@ class DelimitedRecordParser extends BaseRecordParser implements RecordParser {
 		}
 
 		List<DelimitedFieldDescriptor> delimitedFieldDescriptors = getRecordDescriptor().getFieldDescriptors();
-		String[] textTokens = text.split(RegexUtil.escapeRegexMetacharacters(getRecordDescriptor().getDelimiter()));
+		String[] textTokens = text.split(RegexUtil.escapeRegexMetacharacters(getRecordDescriptor().getDelimiter()), -1);
 		int tokensQtt = textTokens.length;
 		for(int i = 0; i < delimitedFieldDescriptors.size(); i++) {
 			DelimitedFieldDescriptor actualFieldDescriptor = delimitedFieldDescriptors.get(i);

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/PositionalRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/PositionalRecordParser.java
@@ -52,8 +52,8 @@ class PositionalRecordParser extends BaseRecordParser implements RecordParser {
 
 		for (int i = 0; i < positionalFieldDescriptors.size(); i++) {
 			final PositionalFieldDescriptor actualFieldDescriptor = positionalFieldDescriptors.get(i);
-
 			final PositionalFieldDescriptor previousFieldDescriptor = readPreviousFieldDescriptors(positionalFieldDescriptors, i);
+
 			final boolean isFirstFieldDescriptor =  previousFieldDescriptor == null;
 
 			final String fieldValue = readFieldValueFromRecord(record, actualFieldDescriptor);
@@ -197,21 +197,24 @@ class PositionalRecordParser extends BaseRecordParser implements RecordParser {
 	private String readFieldValue(String text, PositionalFieldDescriptor actualFieldDescriptor, PositionalFieldDescriptor previousFieldDescriptor) {
 		String fieldValue = StringUtil.EMPTY;
 		int initialIndex = 0;
-		int finalIndex = 0 ;actualFieldDescriptor.getFinalPosition();
+		int finalIndex = 0 ;
 		if (actualFieldDescriptor.isRemainPosition()){
 			if (previousFieldDescriptor != null){
 				if (text.length() > previousFieldDescriptor.getFinalPosition()) {
 					initialIndex = previousFieldDescriptor.getFinalPosition();
 				}
 			}
-			finalIndex = text.length();
-			fieldValue = text.substring(initialIndex, finalIndex);
+			if (previousFieldDescriptor == null || (initialIndex > 0 && initialIndex <  text.length())){
+				finalIndex = text.length();
+				fieldValue = text.substring(initialIndex, finalIndex);
+			}
         }else {
 			initialIndex = actualFieldDescriptor.getInitialPosition() - 1;
 			finalIndex = actualFieldDescriptor.getFinalPosition();
 			if (text.length() < finalIndex) {
 				if (!((PositionalRecordDescriptor) recordDescriptor).isIgnorePositionNotFound()) {
-					throw new RecordParserException("The text length is less than the declared length in field mapping: " + actualFieldDescriptor.getGetter());
+					final String fieldName = actualFieldDescriptor.getGetter() != null ? actualFieldDescriptor.getGetter().getName() : actualFieldDescriptor.getField().getName();
+					throw new RecordParserException("The text length is less than the declared length in field mapping: " + fieldName);
 				}
 				if (text.length() > initialIndex && initialIndex >= 0) {
 					fieldValue = text.substring(initialIndex);

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/PositionalRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/PositionalRecordParser.java
@@ -1,6 +1,5 @@
 package com.github.ffpojo.parser;
 
-import com.github.ffpojo.exception.FFPojoException;
 import com.github.ffpojo.exception.FieldDecoratorException;
 import com.github.ffpojo.exception.RecordParserException;
 import com.github.ffpojo.metadata.FieldDecorator;
@@ -9,7 +8,6 @@ import com.github.ffpojo.metadata.positional.PositionalRecordDescriptor;
 import com.github.ffpojo.util.ReflectUtil;
 import com.github.ffpojo.util.StringUtil;
 
-import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.List;
 
@@ -134,15 +132,10 @@ class PositionalRecordParser extends BaseRecordParser implements RecordParser {
             try {
                 setter = ReflectUtil.getSetterFromGetter(actualFieldDescriptor.getGetter(), new Class<?>[] {getterReturnType}, recordClazz);
             } catch (NoSuchMethodException e2) {
-				e2.printStackTrace();
-//                throw new RecordParserException("Compatible setter not found for getter " + actualFieldDescriptor.getGetter(), e2);
+                logger.warning("Compatible setter not found for getter " + actualFieldDescriptor.getGetter());
             }
         }
-		if (setter != null){
-			setValueBySetterMethod(record, actualFieldDescriptor, fieldValue, setter);
-		}else{
-			setValueByField(record, actualFieldDescriptor, fieldValue);
-		}
+		setValue(record, actualFieldDescriptor, fieldValue, setter);
 	}
 
 	private String readFieldValue(String text, PositionalFieldDescriptor actualFieldDescriptor, PositionalFieldDescriptor previousFieldDescriptor) {

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/PositionalRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/PositionalRecordParser.java
@@ -43,6 +43,9 @@ class PositionalRecordParser extends BaseRecordParser implements RecordParser {
 
 		for (int i = 0; i < positionalFieldDescriptors.size(); i++) {
 			final PositionalFieldDescriptor actualFieldDescriptor = positionalFieldDescriptors.get(i);
+			if (actualFieldDescriptor.isFullLineField()){
+				continue;
+			}
 			final PositionalFieldDescriptor previousFieldDescriptor = readPreviousFieldDescriptors(positionalFieldDescriptors, i);
 
 			final boolean isFirstFieldDescriptor =  previousFieldDescriptor == null;
@@ -50,7 +53,7 @@ class PositionalRecordParser extends BaseRecordParser implements RecordParser {
 			final String fieldValue = readFieldValueFromRecord(record, actualFieldDescriptor);
 			int fieldLength = actualFieldDescriptor.getFinalPosition() - actualFieldDescriptor.getInitialPosition() + 1;
 			String sizedFieldValue = StringUtil.fillToLength(fieldValue, fieldLength, actualFieldDescriptor.getPaddingCharacter(), StringUtil.Direction.valueOf(actualFieldDescriptor.getPaddingAlign().toString()));
-			if (actualFieldDescriptor.isIgnoreMissingFieldsInTheEnd()){
+			if (actualFieldDescriptor.isPositionalFieldRemainder()){
 				sizedFieldValue = fieldValue;
 			}
 			// Check for blank spaces and fill
@@ -145,7 +148,7 @@ class PositionalRecordParser extends BaseRecordParser implements RecordParser {
 		if (actualFieldDescriptor.isFullLineField()){
 			return text;
 		}
-		if (actualFieldDescriptor.isIgnoreMissingFieldsInTheEnd()){
+		if (actualFieldDescriptor.isPositionalFieldRemainder()){
 			if (previousFieldDescriptor != null){
 				if (text.length() > previousFieldDescriptor.getFinalPosition()) {
 					initialIndex = previousFieldDescriptor.getFinalPosition();

--- a/ffpojo/src/main/java/com/github/ffpojo/parser/PositionalRecordParser.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/parser/PositionalRecordParser.java
@@ -50,7 +50,7 @@ class PositionalRecordParser extends BaseRecordParser implements RecordParser {
 			final String fieldValue = readFieldValueFromRecord(record, actualFieldDescriptor);
 			int fieldLength = actualFieldDescriptor.getFinalPosition() - actualFieldDescriptor.getInitialPosition() + 1;
 			String sizedFieldValue = StringUtil.fillToLength(fieldValue, fieldLength, actualFieldDescriptor.getPaddingCharacter(), StringUtil.Direction.valueOf(actualFieldDescriptor.getPaddingAlign().toString()));
-			if (actualFieldDescriptor.isPositionalFieldRemainder()){
+			if (actualFieldDescriptor.isIgnoreMissingFieldsInTheEnd()){
 				sizedFieldValue = fieldValue;
 			}
 			// Check for blank spaces and fill
@@ -142,7 +142,10 @@ class PositionalRecordParser extends BaseRecordParser implements RecordParser {
 		String fieldValue = StringUtil.EMPTY;
 		int initialIndex = 0;
 		int finalIndex;
-		if (actualFieldDescriptor.isPositionalFieldRemainder()){
+		if (actualFieldDescriptor.isFullLineField()){
+			return text;
+		}
+		if (actualFieldDescriptor.isIgnoreMissingFieldsInTheEnd()){
 			if (previousFieldDescriptor != null){
 				if (text.length() > previousFieldDescriptor.getFinalPosition()) {
 					initialIndex = previousFieldDescriptor.getFinalPosition();

--- a/ffpojo/src/main/java/com/github/ffpojo/reader/DelimitedRecordAnnotationMetadataReader.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/reader/DelimitedRecordAnnotationMetadataReader.java
@@ -57,7 +57,11 @@ class DelimitedRecordAnnotationMetadataReader extends AnnotationMetadataReader {
 			if (annotationFieldManager.isDelimitedField(annotation.annotationType())) {
 				DelimitedFieldDescriptor fieldDescriptor = createDelimitedDescriptor(annotation);
 				fieldDescriptor.setAccessorType(AccessorType.FIELD);
-				fieldDescriptor.setField(field);
+				try {
+					fieldDescriptor.setGetter(ReflectUtil.getGetterFromFieldName(field.getName(), recordClazz));
+				} catch (NoSuchMethodException e) {
+					throw new FFPojoException(String.format("Not found getter method to field %s ", field.getName()), e);
+				}
 				fieldDescriptors.add(fieldDescriptor);
 			}
 		}

--- a/ffpojo/src/main/java/com/github/ffpojo/reader/PositionalRecordAnnotationMetadataReader.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/reader/PositionalRecordAnnotationMetadataReader.java
@@ -108,7 +108,7 @@ class PositionalRecordAnnotationMetadataReader extends AnnotationMetadataReader 
 			final boolean isFullLineField = annotationFieldManager.isFullLineField(clazz);
 			final boolean isPositionalFieldRemainder = annotationFieldManager.isPositionalFieldRemainder(clazz);
 			fieldDescriptor.setIsFullLineField(isFullLineField);
-			fieldDescriptor.setRemainPosition(isPositionalFieldRemainder);
+			fieldDescriptor.setIgnoreMissingFieldsInTheEnd(isPositionalFieldRemainder);
 			if (!(isFullLineField || isPositionalFieldRemainder)){
 				fieldDescriptor.setDecorator(annotationFieldManager.createNewInstanceDecorator(positionalFieldAnnotation));
 				fieldDescriptor.setFinalPosition(((Integer) clazz.getMethod("finalPosition").invoke(positionalFieldAnnotation)));

--- a/ffpojo/src/main/java/com/github/ffpojo/reader/PositionalRecordAnnotationMetadataReader.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/reader/PositionalRecordAnnotationMetadataReader.java
@@ -101,15 +101,18 @@ class PositionalRecordAnnotationMetadataReader extends AnnotationMetadataReader 
 		PositionalFieldDescriptor fieldDescriptor = new PositionalFieldDescriptor();
 		Class<? extends Annotation> clazz =  positionalFieldAnnotation.annotationType();
 		try{
+			fieldDescriptor.setDecorator(new DefaultFieldDecorator());
+			if(annotationFieldManager.isFullLineField(clazz)){
+				fieldDescriptor.setIsFullLineField(true);
+				return fieldDescriptor;
+			}
+
 			fieldDescriptor.setPaddingAlign(((PaddingAlign) clazz.getMethod("paddingAlign").invoke(positionalFieldAnnotation)));
 			fieldDescriptor.setPaddingCharacter((((Character) clazz.getMethod("paddingCharacter").invoke(positionalFieldAnnotation))));
 			fieldDescriptor.setTrimOnRead(((Boolean) clazz.getMethod("trimOnRead").invoke(positionalFieldAnnotation)));
-			fieldDescriptor.setDecorator(new DefaultFieldDecorator());
-			final boolean isFullLineField = annotationFieldManager.isFullLineField(clazz);
 			final boolean isPositionalFieldRemainder = annotationFieldManager.isPositionalFieldRemainder(clazz);
-			fieldDescriptor.setIsFullLineField(isFullLineField);
-			fieldDescriptor.setIgnoreMissingFieldsInTheEnd(isPositionalFieldRemainder);
-			if (!(isFullLineField || isPositionalFieldRemainder)){
+			fieldDescriptor.setIsPositionalFieldRemainder(isPositionalFieldRemainder);
+			if (!(isPositionalFieldRemainder)){
 				fieldDescriptor.setDecorator(annotationFieldManager.createNewInstanceDecorator(positionalFieldAnnotation));
 				fieldDescriptor.setFinalPosition(((Integer) clazz.getMethod("finalPosition").invoke(positionalFieldAnnotation)));
 				fieldDescriptor.setInitialPosition(((Integer) clazz.getMethod("initialPosition").invoke(positionalFieldAnnotation)));

--- a/ffpojo/src/main/java/com/github/ffpojo/util/ReflectUtil.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/util/ReflectUtil.java
@@ -1,11 +1,14 @@
 package com.github.ffpojo.util;
 
+import com.github.ffpojo.metadata.delimited.annotation.DelimitedRecord;
+import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.*;
 
-import com.github.ffpojo.metadata.delimited.annotation.DelimitedRecord;
-import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
+import static com.github.ffpojo.util.StringUtil.camelCaseToPastelCase;
+import static com.github.ffpojo.util.StringUtil.pastelCaseToCamelCase;
 
 public class ReflectUtil {
 
@@ -54,10 +57,9 @@ public class ReflectUtil {
 		return clazz.getMethod("set" + fieldNamePastelCase, parameterTypes);
 	}
 
-	public static Method getGetterFromFieldName(String fieldName, Class<?> clazz)
-			throws SecurityException, NoSuchMethodException {
-		String getterNameAsDefault = "get" + ReflectUtil.camelCaseToPastelCase(fieldName);
-		String getterNameAsBoolean = "is" + ReflectUtil.camelCaseToPastelCase(fieldName);
+	public static Method getGetterFromFieldName(String fieldName, Class<?> clazz) throws SecurityException, NoSuchMethodException {
+		String getterNameAsDefault = "get" + camelCaseToPastelCase(fieldName);
+		String getterNameAsBoolean = "is" + camelCaseToPastelCase(fieldName);
 		Method getter = null;
 		try {
 			getter = clazz.getMethod(getterNameAsDefault, (Class[]) null);
@@ -108,14 +110,6 @@ public class ReflectUtil {
 		return true;
 	}
 
-	private static String pastelCaseToCamelCase(String sPastel) {
-		char firstChar = sPastel.charAt(0);
-		return String.valueOf(Character.toLowerCase(firstChar)) + sPastel.substring(1);
-	}
 
-	private static String camelCaseToPastelCase(String sCamel) {
-		char firstChar = sCamel.charAt(0);
-		return String.valueOf(Character.toUpperCase(firstChar)) + sCamel.substring(1);
-	}
 
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/util/ReflectUtil.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/util/ReflectUtil.java
@@ -13,6 +13,7 @@ import static com.github.ffpojo.util.StringUtil.pastelCaseToCamelCase;
 public class ReflectUtil {
 
 	public static boolean isGetter(Method method) {
+		if (method == null) return false;
 		if (!method.getName().startsWith("get") && !method.getName().startsWith("is")) {
 			return false;
 		} else if (method.getName().equals("getClass")) {
@@ -83,6 +84,20 @@ public class ReflectUtil {
 		return new ArrayList<Field>(listaFields);
 	}
 
+	public static Field getField(Class<?> recordClazz, String fieldName){
+		List<Field> fields =  getRecursiveFields(recordClazz);
+		Class<?> clazz = recordClazz;
+		Field field = null;
+		while (clazz.isAnnotationPresent(PositionalRecord.class) || clazz.isAnnotationPresent(DelimitedRecord.class)) {
+			try {
+				field =  clazz.getDeclaredField(fieldName);
+				return field;
+			} catch (NoSuchFieldException e) {}
+			clazz = clazz.getSuperclass();
+		}
+		return field;
+	}
+
 	public static List<Field> getAnnotadedFields(Class<?> recordClazz) {
 		final List<Field> listaFields = new ArrayList<Field>();
 		if (recordClazz.isAnnotationPresent(PositionalRecord.class) || recordClazz.isAnnotationPresent(DelimitedRecord.class)) {
@@ -109,7 +124,4 @@ public class ReflectUtil {
 		}
 		return true;
 	}
-
-
-
 }

--- a/ffpojo/src/main/java/com/github/ffpojo/util/StringUtil.java
+++ b/ffpojo/src/main/java/com/github/ffpojo/util/StringUtil.java
@@ -10,7 +10,7 @@ public class StringUtil {
 	}
 	
 	public static String fillToLength(String s, int length, char fillWith, Direction inDirection) {
-		if (length < 0) {
+		if (length <= 0) {
 			return s;
 		} else {
 			int actualLength = s.length();
@@ -37,5 +37,26 @@ public class StringUtil {
 	public static boolean isNullOrEmpty(String s) {
 		return s == null || s.trim().equals("");
 	}
+
+	public static boolean isNotEmpty(String s){
+		return not(isNullOrEmpty(s));
+	}
+
+	public static String pastelCaseToCamelCase(String sPastel) {
+		if (isNullOrEmpty(sPastel)) return sPastel;
+		char firstChar = sPastel.charAt(0);
+		return String.valueOf(Character.toLowerCase(firstChar)) + sPastel.substring(1);
+	}
+
+	public static String camelCaseToPastelCase(String sCamel) {
+		if (isNullOrEmpty(sCamel)) return sCamel;
+		char firstChar = sCamel.charAt(0);
+		return String.valueOf(Character.toUpperCase(firstChar)) + sCamel.substring(1);
+	}
+
+	private static boolean not(boolean value){
+		return !value;
+	}
+
 	
 }

--- a/ffpojo/src/test/java/com/github/ffpojo/beans/Document.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/beans/Document.java
@@ -3,7 +3,7 @@ package com.github.ffpojo.beans;
 import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
 import com.github.ffpojo.metadata.positional.annotation.extra.DatePositionalField;
-import com.github.ffpojo.metadata.positional.annotation.extra.RemainPositionalField;
+import com.github.ffpojo.metadata.positional.annotation.extra.PositionalFieldRemainder;
 
 import java.util.Date;
 
@@ -24,7 +24,7 @@ public class Document {
     @PositionalField(initialPosition = 29, finalPosition = 49)
     private String publisher;
 
-    @RemainPositionalField
+    @PositionalFieldRemainder
     private String comments;
 
     public String getAuthor() {

--- a/ffpojo/src/test/java/com/github/ffpojo/beans/Document.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/beans/Document.java
@@ -12,7 +12,7 @@ import java.util.Date;
  * @author William Miranda
  */
 
-@PositionalRecord(ignorePositionNotFound = true)
+@PositionalRecord(ignoreMissingFieldsInTheEnd = true)
 public class Document {
 
     @PositionalField(initialPosition = 1, finalPosition = 20)

--- a/ffpojo/src/test/java/com/github/ffpojo/beans/Document.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/beans/Document.java
@@ -1,5 +1,6 @@
 package com.github.ffpojo.beans;
 
+import com.github.ffpojo.metadata.FullLineField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
 import com.github.ffpojo.metadata.positional.annotation.extra.DatePositionalField;
@@ -26,6 +27,9 @@ public class Document {
 
     @PositionalFieldRemainder
     private String comments;
+
+    @FullLineField
+    private String fullLine;
 
     public String getAuthor() {
         return author;
@@ -57,6 +61,10 @@ public class Document {
 
     public void setComments(String comments) {
         this.comments = comments;
+    }
+
+    public String getFullLine() {
+        return fullLine;
     }
 
     @Override

--- a/ffpojo/src/test/java/com/github/ffpojo/beans/Document.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/beans/Document.java
@@ -12,7 +12,7 @@ import java.util.Date;
  * @author William Miranda
  */
 
-@PositionalRecord
+@PositionalRecord(ignorePositionNotFound = true)
 public class Document {
 
     @PositionalField(initialPosition = 1, finalPosition = 20)
@@ -23,6 +23,7 @@ public class Document {
 
     @PositionalField(initialPosition = 29, finalPosition = 49)
     private String publisher;
+
     @RemainPositionalField
     private String comments;
 

--- a/ffpojo/src/test/java/com/github/ffpojo/beans/Employee.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/beans/Employee.java
@@ -6,7 +6,7 @@ import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
 import com.github.ffpojo.metadata.positional.annotation.extra.ListPositionalField;
 
-@PositionalRecord(ignorePositionNotFound=true)
+@PositionalRecord(ignoreMissingFieldsInTheEnd =true)
 public class Employee{
 	@PositionalField(initialPosition=1, finalPosition=10)
 	private String name;

--- a/ffpojo/src/test/java/com/github/ffpojo/beans/Project.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/beans/Project.java
@@ -2,12 +2,11 @@ package com.github.ffpojo.beans;
 
 import java.util.Date;
 
-import com.github.ffpojo.metadata.positional.annotation.AccessorType;
 import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
 import com.github.ffpojo.metadata.positional.annotation.extra.DatePositionalField;
 
-@PositionalRecord(ignorePositionNotFound=true)
+@PositionalRecord(ignoreMissingFieldsInTheEnd =true)
 public class Project{
 	@PositionalField(initialPosition=1, finalPosition=10)
 	private String description;

--- a/ffpojo/src/test/java/com/github/ffpojo/decorator/EnumDecoratorTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/decorator/EnumDecoratorTest.java
@@ -6,7 +6,7 @@ import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
 import com.github.ffpojo.metadata.positional.annotation.extra.DatePositionalField;
 import com.github.ffpojo.metadata.positional.annotation.extra.EnumPositionalField;
-import com.github.ffpojo.metadata.positional.annotation.extra.RemainPositionalField;
+import com.github.ffpojo.metadata.positional.annotation.extra.PositionalFieldRemainder;
 import com.google.common.truth.Truth;
 import org.junit.Test;
 
@@ -99,7 +99,7 @@ public class EnumDecoratorTest {
         @PositionalField(initialPosition = 21, finalPosition = 30)
         private String nome;
 
-        @RemainPositionalField
+        @PositionalFieldRemainder
         private String message;
 
         public String getNome() {

--- a/ffpojo/src/test/java/com/github/ffpojo/decorator/EnumDecoratorTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/decorator/EnumDecoratorTest.java
@@ -27,8 +27,10 @@ public class EnumDecoratorTest {
         fFpojoGitLog.setNome("Manoel");
         fFpojoGitLog.setMessage("Teste anotacao @EnumPositionalField");
         String expected = FFPojoHelper.getInstance().parseToText(fFpojoGitLog);
+        System.out.println(expected);
         FFpojoGitLog other =  FFPojoHelper.getInstance().createFromText(FFpojoGitLog.class, expected);
         String actual = FFPojoHelper.getInstance().parseToText(other);
+        System.out.println(actual);
         Truth.assert_().that(actual).isEqualTo(expected);
         Truth.assert_().that(other).isEqualTo(fFpojoGitLog);
         Truth.assert_().that(other.getColaborator()).isEqualTo(Colaborator.WILLIAM);
@@ -42,6 +44,7 @@ public class EnumDecoratorTest {
         fFpojoGitLog.setMessage("Teste anotacao @EnumPositionalField");
         fFpojoGitLog.setNome("Josefina");
         String expected = FFPojoHelper.getInstance().parseToText(fFpojoGitLog);
+        System.out.println(expected);
         FFpojoGitLog other =  FFPojoHelper.getInstance().createFromText(FFpojoGitLogOrdinal.class, expected);
         String actual = FFPojoHelper.getInstance().parseToText(other);
         Truth.assert_().that(actual).isEqualTo(expected);

--- a/ffpojo/src/test/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManagerTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/metadata/extra/FFPojoAnnotationFieldManagerTest.java
@@ -2,10 +2,14 @@ package com.github.ffpojo.metadata.extra;
 
 import com.github.ffpojo.decorator.*;
 import com.github.ffpojo.exception.FFPojoException;
+import com.github.ffpojo.metadata.DefaultFieldDecorator;
+import com.github.ffpojo.metadata.FieldDecorator;
 import com.github.ffpojo.metadata.delimited.annotation.extra.*;
+import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
 import com.github.ffpojo.metadata.positional.annotation.extra.*;
 import com.google.common.truth.Truth;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -17,9 +21,20 @@ import org.junit.rules.ExpectedException;
 public class FFPojoAnnotationFieldManagerTest {
 
     final FFPojoAnnotationFieldManager annotationFieldManager =  new FFPojoAnnotationFieldManager();
+    IntegerPositionalField integerPositionalField;
+    BooleanDelimitedField booleanDelimitedField;
+    PositionalField positionalField;
+
 
     @Rule
     public ExpectedException expectedException = ExpectedException.none();
+
+    @Before
+    public void setUp() throws Exception {
+        integerPositionalField = Mock.class.getDeclaredMethod("getTestIntegerPositionalField").getDeclaredAnnotation(IntegerPositionalField.class);
+        positionalField = Mock.class.getDeclaredMethod("getTestPositionalField").getDeclaredAnnotation(PositionalField.class);
+        booleanDelimitedField = Mock.class.getDeclaredMethod("getTestDelimitedField").getDeclaredAnnotation(BooleanDelimitedField.class);
+    }
 
     @Test
     public void shouldToReturnDateDecoratorWhenDateDelimitedField(){
@@ -45,7 +60,6 @@ public class FFPojoAnnotationFieldManagerTest {
         Truth.assert_().that(decorator).isEqualTo(InternalLongDecorator.class);
     }
 
-
     @Test
     public void shouldToReturnBigIntegerDecoratorWhenBigIntegerDelimitedField(){
         Class<?> decorator =  annotationFieldManager.getClassDecorator(BigIntegerDelimitedField.class);
@@ -58,7 +72,6 @@ public class FFPojoAnnotationFieldManagerTest {
         Truth.assert_().that(decorator).isEqualTo(InternalBigIntegerDecorator.class);
     }
 
-
     @Test
     public void shouldToReturnIntegerDecoratorWhenIntegerDelimitedField(){
         Class<?> decorator =  annotationFieldManager.getClassDecorator(IntegerDelimitedField.class);
@@ -70,7 +83,6 @@ public class FFPojoAnnotationFieldManagerTest {
         Class<?> decorator =  annotationFieldManager.getClassDecorator(IntegerPositionalField.class);
         Truth.assert_().that(decorator).isEqualTo(InternalIntegerDecorator.class);
     }
-
 
     @Test
     public void shouldToReturnBigDecimalDecoratorWhenBigDecimalDelimitedField(){
@@ -97,7 +109,6 @@ public class FFPojoAnnotationFieldManagerTest {
         Truth.assert_().that(decorator).isEqualTo(InternalDoubleDecorator.class);
     }
 
-
     @Test
     public void shouldToReturnFloatDecoratorWhenFloatDelimitedField(){
         Class<?> decorator =  annotationFieldManager.getClassDecorator(FloatDelimitedField.class);
@@ -121,7 +132,6 @@ public class FFPojoAnnotationFieldManagerTest {
         Class<?> decorator =  annotationFieldManager.getClassDecorator(ListPositionalField.class);
         Truth.assert_().that(decorator).isEqualTo(InternalListDecorator.class);
     }
-
 
     @Test
     public void shouldToReturnSetDecoratorWhenSetDelimitedField(){
@@ -147,6 +157,55 @@ public class FFPojoAnnotationFieldManagerTest {
         Truth.assert_().that(decorator).isEqualTo(InternalBooleanDecorator.class);
     }
 
+    @Test
+    public void shouldToReturnTrueIfDelimitedFieldAnnotation(){
+        final boolean delimitedField = annotationFieldManager.isDelimitedField(BigDecimalDelimitedField.class);
+        Truth.assert_().that(delimitedField).isTrue();
+    }
+
+    @Test
+    public void shouldToReturnFalseIfIsNotDelimitedFieldAnnotation(){
+        final boolean delimitedField = annotationFieldManager.isDelimitedField(BigDecimalPositionalField.class);
+        Truth.assert_().that(delimitedField).isFalse();
+    }
+
+    @Test
+    public void shouldToReturnTrueIfPositionalFieldAnnotation(){
+        final boolean positionalField = annotationFieldManager.isPositionalField(BigDecimalPositionalField.class);
+        Truth.assert_().that(positionalField).isTrue();
+    }
+
+    @Test
+    public void shouldToReturnFalseIfIsNotPositionalFieldFieldAnnotation(){
+        final boolean positionalField = annotationFieldManager.isPositionalField(BigDecimalDelimitedField.class);
+        Truth.assert_().that(positionalField).isFalse();
+    }
+
+    @Test
+    public void testGetDecoratorInstance() throws Exception {
+        final FieldDecorator<?> newInstanceDecorator = annotationFieldManager.createNewInstanceDecorator(positionalField);
+        Truth.assert_().that(newInstanceDecorator).isInstanceOf(MockDecorator.class);
+    }
+
+    @Test
+    public void testGetDecoratorInstanceInternalIntegerDecorator() throws Exception {
+        final FieldDecorator<?> newInstanceDecorator = annotationFieldManager.createNewInstanceDecorator(integerPositionalField);
+        Truth.assert_().that(newInstanceDecorator).isInstanceOf(InternalIntegerDecorator.class);
+    }
+
+    @Test
+    public void testGetDecoratorInstanceInternalBooleanDecorator() throws Exception {
+        final FieldDecorator<?> newInstanceDecorator = annotationFieldManager.createNewInstanceDecorator(booleanDelimitedField);
+        Truth.assert_().that(newInstanceDecorator).isInstanceOf(InternalBooleanDecorator.class);
+    }
+
+    @Test
+    public void testIsFieldAnnotedWithFFPojoAnnotation() throws Exception {
+        final boolean isAnnotatedFieldIntMock = annotationFieldManager.isFieldAnnotedWithFFPojoAnnotation(Mock.class.getField("intMock"));
+        Truth.assert_().that(isAnnotatedFieldIntMock).isTrue();
+
+
+    }
 
     @Test
     public void shouldToThrowFFPojoExceptionWhenNotFFPojoAnnotationFieldClass(){
@@ -154,4 +213,26 @@ public class FFPojoAnnotationFieldManagerTest {
         expectedException.expect(FFPojoException.class);
         annotationFieldManager.getClassDecorator(PositionalRecord.class);
     }
+}
+class Mock{
+    @PositionalField(initialPosition = 0, finalPosition = 1)
+    public int intMock;
+
+    @IntegerPositionalField(initialPosition = 0, finalPosition = 1)
+    public int getTestIntegerPositionalField() {
+        return 0;
+    }
+
+    @BooleanDelimitedField(positionIndex = 0)
+    public boolean getTestDelimitedField() {
+        return true;
+    }
+
+    @PositionalField(initialPosition = 0, finalPosition = 1, decorator = MockDecorator.class)
+    public boolean getTestPositionalField(){
+        return false;
+    }
+}
+class MockDecorator extends DefaultFieldDecorator{
+
 }

--- a/ffpojo/src/test/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptorTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptorTest.java
@@ -1,0 +1,35 @@
+package com.github.ffpojo.metadata.positional;
+
+import com.github.ffpojo.metadata.FullLineField;
+import com.github.ffpojo.metadata.positional.annotation.PositionalField;
+import com.github.ffpojo.metadata.positional.annotation.extra.PositionalFieldRemainder;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by William on 02/01/16.
+ */
+public class PositionalFieldDescriptorTest {
+
+    @Test
+    public void testCompareToFullLineField() throws Exception {
+
+
+
+
+    }
+}
+
+class Mock {
+    @FullLineField
+    private String fieldOne;
+    @PositionalFieldRemainder
+    private String fieldTwo;
+    @PositionalField(initialPosition = 1, finalPosition = 2)
+    private String fieldThree;
+    @PositionalField(initialPosition = 3, finalPosition = 4)
+    private String fieldFour;
+    @PositionalField(initialPosition = 4, finalPosition = 5)
+    private String fieldFive;
+}

--- a/ffpojo/src/test/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptorTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptorTest.java
@@ -42,7 +42,7 @@ public class PositionalFieldDescriptorTest {
                 .build();
 
         PositionalFieldDescriptor positionalFieldDescriptorRemainder = PositionalFieldDescriptorBuilder.newInstance()
-                .isIgnoreMissingFieldsInTheEnd()
+                .isPositionalFieldRemainder()
                 .build();
 
         Truth.assert_().that(positionalFieldDescriptor.compareTo(positionalFieldDescriptor2)).isLessThan(0);
@@ -89,8 +89,8 @@ class PositionalFieldDescriptorBuilder{
         return this;
     }
 
-    public PositionalFieldDescriptorBuilder isIgnoreMissingFieldsInTheEnd(){
-        this.positionalFieldDescriptor.setIgnoreMissingFieldsInTheEnd(true);
+    public PositionalFieldDescriptorBuilder isPositionalFieldRemainder(){
+        this.positionalFieldDescriptor.setIsPositionalFieldRemainder(true);
         return this;
     }
 

--- a/ffpojo/src/test/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptorTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/metadata/positional/PositionalFieldDescriptorTest.java
@@ -1,9 +1,16 @@
 package com.github.ffpojo.metadata.positional;
 
+import com.github.ffpojo.metadata.FieldDescriptor;
 import com.github.ffpojo.metadata.FullLineField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.extra.PositionalFieldRemainder;
+import com.google.common.truth.Truth;
 import org.junit.Test;
+
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static org.junit.Assert.*;
 
@@ -14,22 +21,91 @@ public class PositionalFieldDescriptorTest {
 
     @Test
     public void testCompareToFullLineField() throws Exception {
+        PositionalFieldDescriptor positionalFieldDescriptor = PositionalFieldDescriptorBuilder.newInstance()
+                .initialPosition(1)
+                .finalPosition(2)
+                .getter(Mock.class.getDeclaredMethod("getName"))
+                .build();
 
 
 
+        PositionalFieldDescriptor positionalFieldDescriptor2 = PositionalFieldDescriptorBuilder.newInstance()
+                .initialPosition(3)
+                .finalPosition(4)
+                .getter(Mock.class.getDeclaredMethod("getAge"))
+                .build();
+
+        positionalFieldDescriptor.setGetter(Mock.class.getDeclaredMethod("getName"));
+
+        PositionalFieldDescriptor positionalFieldDescriptorFull = PositionalFieldDescriptorBuilder.newInstance()
+                .isFullLine()
+                .build();
+
+        PositionalFieldDescriptor positionalFieldDescriptorRemainder = PositionalFieldDescriptorBuilder.newInstance()
+                .isIgnoreMissingFieldsInTheEnd()
+                .build();
+
+        Truth.assert_().that(positionalFieldDescriptor.compareTo(positionalFieldDescriptor2)).isLessThan(0);
+        Truth.assert_().that(positionalFieldDescriptor2.compareTo(positionalFieldDescriptor)).isGreaterThan(0);
+        Truth.assert_().that(positionalFieldDescriptor2.compareTo(positionalFieldDescriptorFull)).isLessThan(0);
+        Truth.assert_().that(positionalFieldDescriptorFull.compareTo(positionalFieldDescriptorRemainder)).isGreaterThan(0);
+        Truth.assert_().that(positionalFieldDescriptorRemainder.compareTo(positionalFieldDescriptorFull)).isLessThan(0);
+
+        Set<FieldDescriptor> fieldDescriptorSet =  new TreeSet<FieldDescriptor>();
+        fieldDescriptorSet.add(positionalFieldDescriptorRemainder);
+        fieldDescriptorSet.add(positionalFieldDescriptorFull);
+        fieldDescriptorSet.add(positionalFieldDescriptor);
+        fieldDescriptorSet.add(positionalFieldDescriptor2);
+
+        final Iterator<FieldDescriptor> iterator = fieldDescriptorSet.iterator();
+        Truth.assert_().that(iterator.next()).isEqualTo(positionalFieldDescriptor);
+        Truth.assert_().that(iterator.next()).isEqualTo(positionalFieldDescriptor2);
+        Truth.assert_().that(iterator.next()).isEqualTo(positionalFieldDescriptorRemainder);
+        Truth.assert_().that(iterator.next()).isEqualTo(positionalFieldDescriptorFull);
 
     }
 }
 
-class Mock {
-    @FullLineField
-    private String fieldOne;
-    @PositionalFieldRemainder
-    private String fieldTwo;
-    @PositionalField(initialPosition = 1, finalPosition = 2)
-    private String fieldThree;
-    @PositionalField(initialPosition = 3, finalPosition = 4)
-    private String fieldFour;
-    @PositionalField(initialPosition = 4, finalPosition = 5)
-    private String fieldFive;
+class PositionalFieldDescriptorBuilder{
+
+    final PositionalFieldDescriptor positionalFieldDescriptor =  new PositionalFieldDescriptor();
+
+    public static PositionalFieldDescriptorBuilder newInstance(){
+        return new PositionalFieldDescriptorBuilder();
+    }
+
+    public PositionalFieldDescriptorBuilder initialPosition(int initValue){
+        this.positionalFieldDescriptor.setInitialPosition(initValue);
+        return this;
+    }
+
+    public PositionalFieldDescriptorBuilder finalPosition(int finalValue){
+        this.positionalFieldDescriptor.setFinalPosition(finalValue);
+        return this;
+    }
+
+    public PositionalFieldDescriptorBuilder isFullLine(){
+        this.positionalFieldDescriptor.setIsFullLineField(true);
+        return this;
+    }
+
+    public PositionalFieldDescriptorBuilder isIgnoreMissingFieldsInTheEnd(){
+        this.positionalFieldDescriptor.setIgnoreMissingFieldsInTheEnd(true);
+        return this;
+    }
+
+    public PositionalFieldDescriptorBuilder getter(Method getter){
+        this.positionalFieldDescriptor.setGetter(getter);
+        return this;
+    }
+
+    public PositionalFieldDescriptor build(){
+        return this.positionalFieldDescriptor;
+    }
+
+}
+
+class Mock{
+    public String getName(){return "";}
+    public String getAge(){return "";}
 }

--- a/ffpojo/src/test/java/com/github/ffpojo/test/DelimitedRecordParserTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/test/DelimitedRecordParserTest.java
@@ -1,5 +1,6 @@
 package com.github.ffpojo.test;
 
+import com.google.common.truth.Truth;
 import junit.framework.Assert;
 
 import org.junit.Test;
@@ -144,7 +145,16 @@ public class DelimitedRecordParserTest {
 		String expected = "Giba     St Martin Street";
 		Assert.assertEquals(expected, actual);
 	}
-	
+
+	@Test
+	public void deve_transformar_pojo_em_string_de_acordo_com_anotacoes_considerando_delimitador_como_caractere_de_espaco_composto_sem_metodo_setter() throws FFPojoException {
+		String actual = "Giba     St Martin Street";
+		FFPojoHelper ffpojo = FFPojoHelper.getInstance();
+		TestPojo10WithSetter pojo = ffpojo.createFromText(TestPojo10WithSetter.class, actual);
+		Truth.assert_().that(pojo.getName()).isEqualTo("Giba");
+		Truth.assert_().that(pojo.getAddress()).isEqualTo("St Martin Street");
+	}
+
 	@DelimitedRecord
 	public static final class TestPojo1 {
 		private String name;
@@ -289,5 +299,16 @@ public class DelimitedRecordParserTest {
 		@DelimitedField(positionIndex = 2)
 		public String getAddress() { return address; }
 		public void setAddress(String address) { this.address = address; }
+	}
+
+	@DelimitedRecord(delimiter = "     ")
+	public static final class TestPojo10WithSetter {
+		private String name;
+		private String address;
+		// GETTERS AND SETTERS
+		@DelimitedField(positionIndex = 1)
+		public String getName() { return name; }
+		@DelimitedField(positionIndex = 2)
+		public String getAddress() { return address; }
 	}
 }

--- a/ffpojo/src/test/java/com/github/ffpojo/test/PositionalRecordParserTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/test/PositionalRecordParserTest.java
@@ -134,6 +134,17 @@ public class PositionalRecordParserTest {
 		Truth.assert_().that(actual.getIdade()).isEqualTo(35);
 		Truth.assert_().that(actual.getOpcionalDescricao()).isEqualTo("St Martin Street");
 	}
+
+	@Test
+	public void deveTestarClassWithoutSetter() throws FFPojoException {
+		String expected = "William   35  St Martin Street";
+		FFPojoHelper ffpojo = FFPojoHelper.getInstance();
+		TestImutableClass actual = ffpojo.createFromText(TestImutableClass.class, expected);
+		Truth.assert_().that(actual.getName()).isEqualTo("William");
+		Truth.assert_().that(actual.getIdade()).isEqualTo(35);
+		Truth.assert_().that(actual.getOpcionalDescricao()).isEqualTo("St Martin Street");
+	}
+
 	
 	@Test
 	public void deve_transformar_pojo_em_string_de_acordo_com_anotacoes_considerando_padding_direita_e_padding_caractere() throws FFPojoException {
@@ -322,6 +333,27 @@ public class PositionalRecordParserTest {
 			this.opcionalDescricao = opcionalDescricao;
 		}
 		
-		
+	}
+
+	@PositionalRecord(ignoreMissingFieldsInTheEnd = true)
+	public static final class TestImutableClass{
+		@PositionalField(initialPosition = 1, finalPosition = 10, paddingAlign = PaddingAlign.LEFT, paddingCharacter = '#')
+		private String name;
+		@IntegerPositionalField(initialPosition=11, finalPosition=14)
+		private int idade;
+		@PositionalField(initialPosition=15, finalPosition=3000)
+		private String opcionalDescricao;
+
+		public String getName() {
+			return name;
+		}
+
+		public int getIdade() {
+			return idade;
+		}
+
+		public String getOpcionalDescricao() {
+			return opcionalDescricao;
+		}
 	}
 }

--- a/ffpojo/src/test/java/com/github/ffpojo/test/PositionalRecordParserTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/test/PositionalRecordParserTest.java
@@ -36,6 +36,14 @@ public class PositionalRecordParserTest {
 		Truth.assert_().that(expected.length()).isEqualTo(document.getClass().getDeclaredField("publisher").getAnnotation(PositionalField.class).finalPosition() + document.getComments().length() );
 	}
 
+	@Test
+	public void deve_verificar_que_fullline_annotation_devolve_toda_linha() throws Exception{
+		final String expected = "William Miranda     03112015Casa do Codigo       This comment can to have infinity size, because this attribute is using the annotation @RemainPositional Field.";
+		final Document document = FFPojoHelper.getInstance().createFromText(Document.class, expected);
+		Truth.assert_().that(document.getFullLine()).isEqualTo(expected);
+
+	}
+
 
 	@Test
 	public void deve_verificar_que_remain_anotation_devolve_as_posicoes_restantes_do_texto_sem_preencher_campo_anterior() throws NoSuchFieldException, ParseException {

--- a/ffpojo/src/test/java/com/github/ffpojo/test/PositionalRecordParserTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/test/PositionalRecordParserTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import com.github.ffpojo.FFPojoHelper;
 import com.github.ffpojo.exception.FFPojoException;
 import com.github.ffpojo.metadata.positional.PaddingAlign;
-import com.github.ffpojo.metadata.positional.annotation.AccessorType;
 import com.github.ffpojo.metadata.positional.annotation.PositionalField;
 import com.github.ffpojo.metadata.positional.annotation.PositionalRecord;
 import com.github.ffpojo.metadata.positional.annotation.extra.DoublePositionalField;
@@ -298,7 +297,7 @@ public class PositionalRecordParserTest {
 		public void setName(String name) { this.name = name; }
 	}
 	
-	@PositionalRecord(ignorePositionNotFound=true)
+	@PositionalRecord(ignoreMissingFieldsInTheEnd =true)
 	public static final class TestPojo8 {
 		@PositionalField(initialPosition = 1, finalPosition = 10, paddingAlign = PaddingAlign.LEFT, paddingCharacter = '#')
 		private String name;

--- a/ffpojo/src/test/java/com/github/ffpojo/test/PositionalRecordParserTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/test/PositionalRecordParserTest.java
@@ -23,16 +23,30 @@ import junit.framework.Assert;
 public class PositionalRecordParserTest {
 
 	@Test
-	public void deve_verificar_que_remain_anotation_devolve_as_posicoes_restantes_do_texto() throws NoSuchFieldException {
+	public void deve_verificar_que_remain_anotation_devolve_as_posicoes_restantes_do_texto() throws NoSuchFieldException, ParseException {
+		final String expected = "William Miranda     03112015Casa do Codigo       This comment can to have infinity size, because this attribute is using the annotation @RemainPositional Field.";
 		final Document document = new Document();
 		document.setAuthor("William Miranda");
-		document.setCreation(new Date());
+		document.setCreation(new SimpleDateFormat("ddMMyyyy").parse("03112015"));
 		document.setPublisher("Casa do Codigo");
 		document.setComments("This comment can to have infinity size, because this attribute is using the annotation @RemainPositional Field.");
 
-		String expected =  FFPojoHelper.getInstance().parseToText(document);
-		final Document other =  FFPojoHelper.getInstance().createFromText(Document.class, expected);
-		String result = FFPojoHelper.getInstance().parseToText(other);
+		final String result = FFPojoHelper.getInstance().parseToText(document);
+		Truth.assert_().that(result.length()).isEqualTo(expected.length());
+		Truth.assert_().that(result).isEqualTo(expected);
+		Truth.assert_().that(expected.length()).isEqualTo(document.getClass().getDeclaredField("publisher").getAnnotation(PositionalField.class).finalPosition() + document.getComments().length() );
+	}
+
+
+	@Test
+	public void deve_verificar_que_remain_anotation_devolve_as_posicoes_restantes_do_texto_sem_preencher_campo_anterior() throws NoSuchFieldException, ParseException {
+		final String expected = "William Miranda     03112015                     This comment can to have infinity size, because this attribute is using the annotation @RemainPositional Field.";
+		final Document document = new Document();
+		document.setAuthor("William Miranda");
+		document.setCreation(new SimpleDateFormat("ddMMyyyy").parse("03112015"));
+		document.setComments("This comment can to have infinity size, because this attribute is using the annotation @RemainPositional Field.");
+		final String result = FFPojoHelper.getInstance().parseToText(document);
+
 		Truth.assert_().that(result.length()).isEqualTo(expected.length());
 		Truth.assert_().that(result).isEqualTo(expected);
 		Truth.assert_().that(expected.length()).isEqualTo(document.getClass().getDeclaredField("publisher").getAnnotation(PositionalField.class).finalPosition() + document.getComments().length() );

--- a/ffpojo/src/test/java/com/github/ffpojo/util/StringUtilTest.java
+++ b/ffpojo/src/test/java/com/github/ffpojo/util/StringUtilTest.java
@@ -1,0 +1,114 @@
+package com.github.ffpojo.util;
+
+import com.google.common.truth.Truth;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by William on 23/12/15.
+ */
+public class StringUtilTest {
+
+    @Test
+    public void testFillToLengthLeftDirection() throws Exception {
+        final String initial = "1000";
+        final int finalSize = 20;
+        final char charToFill = '0';
+        final String result = StringUtil.fillToLength(initial, finalSize, charToFill, StringUtil.Direction.LEFT);
+        final String expected = "00000000000000001000";
+        Truth.assert_().that(result).isEqualTo(expected);
+        Truth.assert_().that(result.length()).isEqualTo(finalSize);
+    }
+
+    @Test
+    public void testFillToLengthRightDirection() throws Exception {
+        final String initial = "william";
+        final int finalSize = 20;
+        final char charToFill = ' ';
+        final String result = StringUtil.fillToLength(initial, finalSize, charToFill, StringUtil.Direction.RIGHT);
+        final String expected = "william             ";
+        Truth.assert_().that(result).isEqualTo(expected);
+        Truth.assert_().that(result.length()).isEqualTo(finalSize);
+    }
+
+
+    @Test
+    public void testFillToLengthZeroLength() throws Exception {
+        final String initial = "william";
+        final int finalSize = 0;
+        final char charToFill = ' ';
+        final String result = StringUtil.fillToLength(initial, finalSize, charToFill, StringUtil.Direction.RIGHT);
+        final String expected = initial;
+        Truth.assert_().that(result).isEqualTo(expected);
+        Truth.assert_().that(result.length()).isEqualTo(expected.length());
+    }
+
+    @Test
+    public void testFillToLengthTextLengthMoreThanParamLength() throws Exception {
+        final String initial = "william";
+        final int finalSize = 4;
+        final char charToFill = ' ';
+        final String result = StringUtil.fillToLength(initial, finalSize, charToFill, StringUtil.Direction.RIGHT);
+        final String expected = "will";
+        Truth.assert_().that(result).isEqualTo(expected);
+        Truth.assert_().that(result.length()).isEqualTo(expected.length());
+    }
+
+    @Test
+    public void testIsNullOrEmptyTestingNullValue() throws Exception {
+        final String nullValue =  null;
+        final boolean result = StringUtil.isNullOrEmpty(nullValue);
+        Truth.assert_().that(result).isTrue();
+    }
+
+
+    @Test
+    public void testIsNullOrEmptyTestingEmptyValue() throws Exception {
+        final String emptyValue =  StringUtil.EMPTY;
+        final boolean result = StringUtil.isNullOrEmpty(emptyValue);
+        Truth.assert_().that(result).isTrue();
+    }
+
+
+    @Test
+    public void testIsNullOrEmptyTestingBlankValue() throws Exception {
+        final String blankValue =  "                    ";
+        final boolean result = StringUtil.isNullOrEmpty(blankValue);
+        Truth.assert_().that(result).isTrue();
+    }
+
+    @Test
+    public void testNotNull() throws Exception {
+        final String blankValue =  "william";
+        final boolean result = StringUtil.isNotEmpty(blankValue);
+        Truth.assert_().that(result).isTrue();
+    }
+
+
+    @Test
+    public void testNotNullWithNullValue() throws Exception {
+        final String blankValue =  null;
+        final boolean result = StringUtil.isNotEmpty(blankValue);
+        Truth.assert_().that(result).isFalse();
+    }
+
+
+    @Test
+    public void testPastelCaseToCamelCase() throws Exception {
+        final String initial = "StringUtilTest";
+        final String expected = "stringUtilTest";
+        final String result = StringUtil.pastelCaseToCamelCase(initial);
+        Truth.assert_().that(result).isEqualTo(result);
+
+
+    }
+
+    @Test
+    public void testCamelCaseToPastelCase() throws Exception {
+        final String initial = "stringUtilTest";
+        final String expexcted = "StringUtilTest";
+        final String result = StringUtil.camelCaseToPastelCase(initial);
+        Truth.assert_().that(result).isEqualTo(result);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
 	<groupId>com.github.ffpojo</groupId>
 	<artifactId>ffpojo-parent</artifactId>
-	<version>1.1-SNAPSHOT</version>
+	<version>2.0.REPACKAGE</version>
 	<packaging>pom</packaging>
 
 	<name>FFPOJO Project</name>
@@ -46,6 +46,12 @@
 			<name>Gilberto Augusto Holms</name>
 			<email>gibaholms85@gmail.com</email>
 			<url>http://gibaholms.wordpress.com</url>
+		</developer>
+		<developer>
+			<id>blackstile</id>
+			<name>William Miranda de Jesus</name>
+			<email>blackstile@hotmail.com</email>
+			<url>http://blogdoparanga.wordpress.com</url>
 		</developer>
 	</developers>
 


### PR DESCRIPTION
Correcões solicitadas pelo @gibaholms para a liberacao da nova release.
- Criado ao FullLineField
  - Alterado na annotation PositionalRecord o atributo ignorePositionNotFound para ignoreMissingFieldsInTheEnd
  - Alterado o nome da anotacao @RemainPositionalField para @PositionalFieldRemainder
  - Adicionado o anotacao EnumDelimitedField e EnumPositionalField
  - Alterado para que o valor seja setado prioritariamente pelo metodo setter. Caso um metodo setter não tenha sido definido, para aqueles field que não quere expor o metodo setter, o valor será setado utilizando o field.
  -  Removido o atributo AccesorType da anotacao PositionalRecord. Agora é possível anotar tanto o field quanto o getter, sem precisar informar qual o AccessorType. Caso um field tenha sido anotado e o getter do mesmo tenha sido anotado também, será levado em cosideração a anotação colocada no field.
